### PR TITLE
Add WithoutOmittingSchedule flag to Create/UpdateQueryInput

### DIFF
--- a/query.go
+++ b/query.go
@@ -156,13 +156,14 @@ func (client *Client) CreateFavoriteQuery(ctx context.Context, id int) error {
 }
 
 type CreateQueryInput struct {
-	DataSourceID int                       `json:"data_source_id"`
-	Description  string                    `json:"description,omitempty"`
-	Name         string                    `json:"name"`
-	Options      *CreateQueryInputOptions  `json:"options,omitempty"`
-	Query        string                    `json:"query"`
-	Schedule     *CreateQueryInputSchedule `json:"schedule,omitempty"`
-	Tags         []string                  `json:"tags,omitempty"`
+	DataSourceID            int                       `json:"data_source_id"`
+	Description             string                    `json:"description,omitempty"`
+	Name                    string                    `json:"name"`
+	Options                 *CreateQueryInputOptions  `json:"options,omitempty"`
+	Query                   string                    `json:"query"`
+	Schedule                *CreateQueryInputSchedule `json:"schedule,omitempty"`
+	WithoutOmittingSchedule bool                      `json:"-"`
+	Tags                    []string                  `json:"tags,omitempty"`
 }
 
 type CreateQueryInputOptions struct {
@@ -176,8 +177,32 @@ type CreateQueryInputSchedule struct {
 	DayOfWeek *string `json:"day_of_week"`
 }
 
+type createQueryInputWithSchedule struct {
+	DataSourceID int                       `json:"data_source_id"`
+	Description  string                    `json:"description,omitempty"`
+	Name         string                    `json:"name"`
+	Options      *CreateQueryInputOptions  `json:"options,omitempty"`
+	Query        string                    `json:"query"`
+	Schedule     *CreateQueryInputSchedule `json:"schedule"`
+	Tags         []string                  `json:"tags,omitempty"`
+}
+
 func (client *Client) CreateQuery(ctx context.Context, input *CreateQueryInput) (*Query, error) {
-	res, close, err := client.Post(ctx, "api/queries", input)
+	var body any = input
+
+	if input != nil && input.WithoutOmittingSchedule {
+		body = &createQueryInputWithSchedule{
+			DataSourceID: input.DataSourceID,
+			Description:  input.Description,
+			Name:         input.Name,
+			Options:      input.Options,
+			Query:        input.Query,
+			Schedule:     input.Schedule,
+			Tags:         input.Tags,
+		}
+	}
+
+	res, close, err := client.Post(ctx, "api/queries", body)
 	defer close()
 
 	if err != nil {
@@ -211,14 +236,15 @@ func (client *Client) ForkQuery(ctx context.Context, id int) (*Query, error) {
 }
 
 type UpdateQueryInput struct {
-	DataSourceID int                       `json:"data_source_id,omitempty"`
-	Description  string                    `json:"description,omitempty"`
-	Name         string                    `json:"name,omitempty"`
-	Options      *UpdateQueryInputOptions  `json:"options,omitempty"`
-	Query        string                    `json:"query,omitempty"`
-	Schedule     *UpdateQueryInputSchedule `json:"schedule,omitempty"`
-	Tags         *[]string                 `json:"tags,omitempty"`
-	IsDraft      *bool                     `json:"is_draft,omitempty"`
+	DataSourceID            int                       `json:"data_source_id,omitempty"`
+	Description             string                    `json:"description,omitempty"`
+	Name                    string                    `json:"name,omitempty"`
+	Options                 *UpdateQueryInputOptions  `json:"options,omitempty"`
+	Query                   string                    `json:"query,omitempty"`
+	Schedule                *UpdateQueryInputSchedule `json:"schedule,omitempty"`
+	WithoutOmittingSchedule bool                      `json:"-"`
+	Tags                    *[]string                 `json:"tags,omitempty"`
+	IsDraft                 *bool                     `json:"is_draft,omitempty"`
 }
 
 type UpdateQueryInputOptions struct {
@@ -232,8 +258,34 @@ type UpdateQueryInputSchedule struct {
 	DayOfWeek *string `json:"day_of_week"`
 }
 
+type updateQueryInputWithSchedule struct {
+	DataSourceID int                       `json:"data_source_id,omitempty"`
+	Description  string                    `json:"description,omitempty"`
+	Name         string                    `json:"name,omitempty"`
+	Options      *UpdateQueryInputOptions  `json:"options,omitempty"`
+	Query        string                    `json:"query,omitempty"`
+	Schedule     *UpdateQueryInputSchedule `json:"schedule"`
+	Tags         *[]string                 `json:"tags,omitempty"`
+	IsDraft      *bool                     `json:"is_draft,omitempty"`
+}
+
 func (client *Client) UpdateQuery(ctx context.Context, id int, input *UpdateQueryInput) (*Query, error) {
-	res, close, err := client.Post(ctx, fmt.Sprintf("api/queries/%d", id), input)
+	var body any = input
+
+	if input != nil && input.WithoutOmittingSchedule {
+		body = &updateQueryInputWithSchedule{
+			DataSourceID: input.DataSourceID,
+			Description:  input.Description,
+			Name:         input.Name,
+			Options:      input.Options,
+			Query:        input.Query,
+			Schedule:     input.Schedule,
+			Tags:         input.Tags,
+			IsDraft:      input.IsDraft,
+		}
+	}
+
+	res, close, err := client.Post(ctx, fmt.Sprintf("api/queries/%d", id), body)
 	defer close()
 
 	if err != nil {

--- a/query_test.go
+++ b/query_test.go
@@ -527,6 +527,40 @@ func Test_CreateQuery_OK(t *testing.T) {
 	}, res)
 }
 
+func Test_CreateQuery_OK_WithoutOmittingSchedule(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder(http.MethodPost, "https://redash.example.com/api/queries", func(req *http.Request) (*http.Response, error) {
+		assert.Equal(
+			http.Header(
+				http.Header{
+					"Authorization": []string{"Key " + testRedashAPIKey},
+					"Content-Type":  []string{"application/json"},
+					"User-Agent":    []string{"redash-go"},
+				},
+			),
+			req.Header,
+		)
+		require.NotNil(req.Body)
+		body, _ := io.ReadAll(req.Body)
+		assert.Equal(`{"data_source_id":1,"description":"description","name":"my-query","query":"select 1","schedule":null}`, string(body))
+		return httpmock.NewStringResponse(http.StatusOK, `{"id":1}`), nil
+	})
+
+	client, _ := redash.NewClient("https://redash.example.com", testRedashAPIKey)
+	_, err := client.CreateQuery(context.Background(), &redash.CreateQueryInput{
+		DataSourceID:            1,
+		Description:             "description",
+		Name:                    "my-query",
+		Query:                   "select 1",
+		WithoutOmittingSchedule: true,
+	})
+	assert.NoError(err)
+}
+
 func Test_CreateQuery_Err_5xx(t *testing.T) {
 	assert := assert.New(t)
 	httpmock.Activate()
@@ -814,6 +848,37 @@ func Test_UpdateQuery_OK_Publish(t *testing.T) {
 			},
 		},
 	}, res)
+}
+
+func Test_UpdateQuery_OK_WithoutOmittingSchedule(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder(http.MethodPost, "https://redash.example.com/api/queries/1", func(req *http.Request) (*http.Response, error) {
+		assert.Equal(
+			http.Header(
+				http.Header{
+					"Authorization": []string{"Key " + testRedashAPIKey},
+					"Content-Type":  []string{"application/json"},
+					"User-Agent":    []string{"redash-go"},
+				},
+			),
+			req.Header,
+		)
+		require.NotNil(req.Body)
+		body, _ := io.ReadAll(req.Body)
+		assert.Equal(`{"name":"my-query","schedule":null}`, string(body))
+		return httpmock.NewStringResponse(http.StatusOK, `{"id":1}`), nil
+	})
+
+	client, _ := redash.NewClient("https://redash.example.com", testRedashAPIKey)
+	_, err := client.UpdateQuery(context.Background(), 1, &redash.UpdateQueryInput{
+		Name:                    "my-query",
+		WithoutOmittingSchedule: true,
+	})
+	assert.NoError(err)
 }
 
 func Test_UpdateQuery_Err_5xx(t *testing.T) {


### PR DESCRIPTION
Allows callers to clear a query's schedule by sending `"schedule": null`. `Schedule` keeps its `omitempty` default (so existing patch-like updates remain unchanged), and setting `WithoutOmittingSchedule = true` forces the field to be serialized as `null`. Mirrors the existing `WithoutOmittingMaxAge` flag on `ExecQueryJSONInput`.

```go
// Clear the schedule
client.UpdateQuery(ctx, id, &redash.UpdateQueryInput{
    WithoutOmittingSchedule: true,
})
// → "schedule": null
```

Needed by winebarrel/terraform-provider-redash#149 to support unsetting schedules from Terraform.