### PR TITLE
Update Change log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-Add `WithoutOmittingSchedule` flag to `Create/UpdateQueryInput`. [pull#328](https://github.com/winebarrel/redash-go/pull/328)
+Add `WithoutOmittingSchedule` flag to `CreateQueryInput`/`UpdateQueryInput`. [pull#328](https://github.com/winebarrel/redash-go/pull/328)
 
 ## [2.9.0] - 2026-02-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.10.0] - 2026-04-29
+
+### Changed
+
+Add `WithoutOmittingSchedule` flag to `Create/UpdateQueryInput`. [pull#328](https://github.com/winebarrel/redash-go/pull/328)
+
 ## [2.9.0] - 2026-02-25
 
 ### Changed


### PR DESCRIPTION
This pull request updates the changelog to document the addition of a new `WithoutOmittingSchedule` flag to the `Create/UpdateQueryInput`. No code changes are included in this pull request.

- Changelog update:
  * Added an entry for version 2.10.0, describing the new `WithoutOmittingSchedule` flag in `Create/UpdateQueryInput`.